### PR TITLE
Fix README formatting and icon availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ License: MIT
 
 ```bash
 ./build-mailspring-appimage.sh
+```

--- a/build-mailspring-appimage.sh
+++ b/build-mailspring-appimage.sh
@@ -168,6 +168,9 @@ if [ -f "$ROOT/$APP-$VERSION-amd64.AppImage" ]; then
     echo ""
 fi
 
+# 📌 Save icon next to AppImage for .desktop file
+cp "$VERSION_DIR/usr/share/icons/hicolor/256x256/apps/"*.png "$ROOT/$APP.png" 2>/dev/null
+
 # 🧹 Clean up .deb file
 if [ -f "$DEB_FILE" ]; then
     echo "🧹 Removing downloaded .deb package"


### PR DESCRIPTION
## Summary
- add missing closing code block in README
- copy icon next to output AppImage for `.desktop` file

## Testing
- `bash -n build-mailspring-appimage.sh`

------
https://chatgpt.com/codex/tasks/task_e_684acf112b588321bed274744af0438f